### PR TITLE
memory improvements

### DIFF
--- a/src/boot.jl
+++ b/src/boot.jl
@@ -18,22 +18,23 @@ end
 function boot_basic(x::AbstractVector, fun::Function, m::Int)
     n = length(x)
     t0 = fun(x)
-    t1 = zeros(m)
+    t1 = zeros(typeof(t0), m)
+    boot_sample = zeros(eltype(x), n)
     for i in 1:m
-        t1[i] = fun(sample(x, n, replace = true))
+        t1[i] = fun(sample!(x, boot_sample))
     end
     res = BootstrapSample(t0, t1, fun, x, m, 0, :basic)
 
     return res
 end
 
-
 function boot_weight(x::AbstractVector, fun::Function, m::Int, weight::WeightVec)
     n = length(x)
     t0 = fun(x)
-    t1 = zeros(m)
+    t1 = zeros(typeof(t0), m)
+    boot_sample = zeros(eltype(x), n)
     for i in 1:m
-        t1[i] = fun(sample(x, weight, n, replace = true))
+        t1[i] = fun(sample!(x, weight, boot_sample))
     end
     res = BootstrapSample(t0, t1, fun, x, m, weight, :weighted)
 
@@ -44,7 +45,7 @@ end
 function boot_balanced(x::AbstractVector, fun::Function, m::Int)
     n = length(x)
     t0 = fun(x)
-    t1 = zeros(m)
+    t1 = zeros(typeof(t0), m)
     idx = repmat([1:n], m)
     ridx = sample(idx, n*m, replace = false)
     ridx = reshape(ridx, n, m)


### PR DESCRIPTION
Suggested change allocates the array used for the bootstrap sample ONCE before the main loop and overwrites its contents each time through.  Seems to save significantly on memory allocation, and a modest improvement in speed.
