### PR TITLE
Added maximum entropy sampling

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,8 @@ The Bootstrap.jl package is licensed under the MIT "Expat" License:
 >
 > Copyright (c) 2014: Jarno Leppänen.
 >
+> Copyright (c) 2017: Kira Huselius Gylling
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including

--- a/src/Bootstrap.jl
+++ b/src/Bootstrap.jl
@@ -28,6 +28,7 @@ export
     AntitheticSampling,
     BalancedSampling,
     ExactSampling,
+    MaximumEntropySampling,
     ResidualSampling,
     WildSampling,
     BootstrapSample,

--- a/src/bootsampling.jl
+++ b/src/bootsampling.jl
@@ -107,7 +107,6 @@ ExactSampling() = ExactSampling(0)
 [Maximum Entropy Sampling](https://cran.r-project.org/web/packages/meboot/vignettes/meboot.pdf)
 
 ```julia
-MaximumEntropySampling()
 MaximumEntropySampling(100)
 maximumEntropySampling(100, MaximumEntropyCache())
 ```
@@ -120,7 +119,7 @@ type MaximumEntropySampling <: BootstrapSampling
     cache::MaximumEntropyCache
 end
 
-MaximumEntropySampling(nrun=0) = MaximumEntropySampling(nrun, MaximumEntropyCache())
+MaximumEntropySampling(nrun) = MaximumEntropySampling(nrun, MaximumEntropyCache())
 
 abstract type BootstrapSample end
 

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -25,3 +25,144 @@ pick(x::AbstractVector, i::AbstractVector) = x[i]
 pick(x::AbstractArray, i::AbstractVector) = slicedim(x, 1, i)
 
 pick(x::AbstractDataFrame, i::AbstractVector) = x[i,:]
+
+"""
+    MaximumEntropyCache{T<:Real}
+
+A cache type for storing precomputed values for a particular input array.
+This is intended to minimize memory allocations and time when drawing random samples.
+
+# Fields
+- `n::Int`: Number of elements in the input array.
+- `t::Type{T}`: `eltype` of the input elements.
+- `inds::Vector{Int}`: Indicies of the sorted data.
+- `values::Vector{T}`: Sorted values of the input data.
+- `Z::Vector{T}`: Intermediate points for the ordered values.
+- `mtrm::T`: Trimmed mean of deviations.
+- `m::Vector{T}`: Mean of the maximum entropy density within each interval.
+- `U::Vector{T}`: Preallocated array for the random noise values.
+- `quantiles::Vector{T}`: Preallocated array for sample quantiles.
+- `v::Vector{T}`
+"""
+type MaximumEntropyCache{T<:Real}
+    n::Int
+    t::Type{T}
+    inds::Vector{Int}
+    vals::Vector{T}
+    Z::Vector{T}
+    mtrm::T
+    m::Vector{T}
+    U::Vector{T}
+    quantiles::Vector{T}
+    v::Vector{T}
+end
+
+function MaximumEntropyCache()
+    MaximumEntropyCache{Float64}(
+        0,
+        Float64,
+        Int[],
+        Float64[],
+        Float64[],
+        0.0,
+        Float64[],
+        Float64[],
+        Float64[],
+        Float64[],
+    )
+end
+
+function init!(cache::MaximumEntropyCache, x::AbstractArray)
+    cache.n = length(x)
+    cache.t = eltype(x)
+    sorted!(cache, x)
+    trimmed!(cache, x)
+    intermediates!(cache)
+    med!(cache)
+    cache.U = zeros(cache.t, cache.n)
+    cache.quantiles = zeros(cache.t, cache.n)
+    cache.v = [y / cache.n for y in 0:cache.n]
+    return nothing
+end
+
+"""
+    sorted!(c::MaximumEntropyCache, x::AbstractArray)
+
+Sets the sorted indices and values for `x`.
+"""
+function sorted!(c::MaximumEntropyCache, x::AbstractArray)
+    c.inds = sortperm(x)
+    c.vals = x[c.inds]
+end
+
+"""
+    trimmed!(c::MaximumEntropyCache, x::AbstractArray)
+
+Compute our trimmed mean of deviations.
+"""
+function trimmed!(c::MaximumEntropyCache, x::AbstractArray)
+    c.mtrm = mean([abs(x[i] - x[i - 1]) for i in 2:c.n])
+end
+
+"""
+    intermediates!(c::MaximumEntropyCache)
+
+Compute our intermediate points for the ordered values.
+"""
+function intermediates!(c::MaximumEntropyCache)
+    c.Z = zeros(c.t, c.n + 1)
+    for i in 2:c.n
+        c.Z[i] = (c.vals[i-1] + c.vals[i]) /  2
+    end
+
+    # Insert our lower and upper tails using our trimmed mean
+    c.Z[1] = (c.vals[1] - c.mtrm)
+    c.Z[end] = (c.vals[end] + c.mtrm)
+end
+
+"""
+    med!(c::MaximumEntropyCache)
+
+Compute the mean of the maximum entropy density within each interval such that
+the ‘mean-preserving constraint’ is satisfied.
+"""
+function med!(c::MaximumEntropyCache)
+    c.m = zeros(c.t, c.n)
+    c.m[1] = 0.75 * c.vals[1] + 0.25 * c.vals[1]
+
+    for k in 2:(c.n-1)
+        c.m[k] = 0.25 * c.vals[k-1] + 0.5 * c.vals[k] + 0.25 * c.vals[k+1]
+    end
+
+    c.m[end] = 0.25 * c.vals[end-1] + 0.75 * c.vals[end]
+end
+
+function draw!(cache::MaximumEntropyCache, x::T, o::T) where T<:AbstractArray
+    # Generate random numbers from the [0, 1] uniform interval.
+    sort!(rand!(cache.U))
+
+    # Compute sample quantiles of the ME density at those points and sort them.
+    for k in 1:cache.n
+        ind = indmin(abs.(cache.v - cache.U[k]))
+
+        if cache.v[ind] > cache.U[k]
+            ind -= 1
+        end
+
+        c = (2 * cache.m[ind] - cache.Z[ind] - cache.Z[ind + 1]) / 2
+        y0 = cache.Z[ind] + c
+        y1 = cache.Z[ind + 1] + c
+        cache.quantiles[k] =
+            y0 + (cache.U[k] - cache.v[ind]) * (y1 - y0) / (cache.v[ind + 1] - cache.v[ind])
+    end
+
+    # Reorder the sorted sample quantiles by using the ordering index.
+    # This recovers the time dependence relationships of the originally observed data.
+    recovered = sortperm(cache.inds)
+    for i in 1:cache.n
+        idx = recovered[i]
+        o[i] = cache.quantiles[idx]
+    end
+
+    return o
+end

--- a/test/bootsample-non-parametric.jl
+++ b/test/bootsample-non-parametric.jl
@@ -14,13 +14,13 @@ function test_bootsample(bs, ref, raw_data, n)
     t0 = original(bs)
     @fact length(t0) --> length(ref)
     [@fact t --> roughly(r) for (t, r) in zip(t0, ref)]
-
+    
     t1 = straps(bs)
     @fact length(t1) --> length(t0)
     [@fact length(t) --> n for t in t1]
     [@fact (minimum(t) <= tr && maximum(t) >= tr) --> true for (t, tr) in zip(t1, t0)]
     [@fact eltype(t) --> eltype(tr) for (t, tr) in zip(t1, t0)]
-
+    
     @fact Bootstrap.data(bs) --> raw_data ## TODO: define scope
 
     @fact nrun(sampling(bs)) --> n
@@ -35,14 +35,14 @@ function test_bootsample(bs, ref, raw_data, n)
     [@fact straps(bs, i) --> straps(bs)[i]  for i in 1:nvar(bs)]
     [@fact bias(bs, i) --> bias(bs)[i]  for i in 1:nvar(bs)]
     [@fact se(bs, i) --> se(bs)[i]  for i in 1:nvar(bs)]
-
+    
     @fact_throws MethodError model(bs)
-
+    
     return Void
 end
 
 function test_ci(bs)
-
+    
     cim_all = (BasicConfInt(), PercentileConfInt(), NormalConfInt(), BCaConfInt())
     for cim in cim_all
         c = ci(bs, cim)
@@ -66,7 +66,7 @@ city_cor(x::AbstractArray) = cor(x[:,1], x[:,2])
 city_cor(x::AbstractDataFrame) = cor(x[:,:X], x[:,:U])
 
 facts("Basic resampling") do
-
+    
     context("city_ratio with DataFrame input") do
         ref = city_ratio(city)
         @fact ref --> roughly(1.5203125)
@@ -121,9 +121,9 @@ facts("Antithetic resampling") do
     end
 
 end
-
+    
 facts("Balanced resampling") do
-
+    
     context("city_ratio with DataFrame input") do
         ref = city_ratio(city)
         @fact ref --> roughly(1.5203125)
@@ -157,7 +157,7 @@ facts("Balanced resampling") do
     end
 
 end
-
+    
 facts("Exact resampling") do
 
     nc = Bootstrap.nrun_exact(nrow(city))

--- a/test/bootsample-non-parametric.jl
+++ b/test/bootsample-non-parametric.jl
@@ -14,13 +14,13 @@ function test_bootsample(bs, ref, raw_data, n)
     t0 = original(bs)
     @fact length(t0) --> length(ref)
     [@fact t --> roughly(r) for (t, r) in zip(t0, ref)]
-    
+
     t1 = straps(bs)
     @fact length(t1) --> length(t0)
     [@fact length(t) --> n for t in t1]
     [@fact (minimum(t) <= tr && maximum(t) >= tr) --> true for (t, tr) in zip(t1, t0)]
     [@fact eltype(t) --> eltype(tr) for (t, tr) in zip(t1, t0)]
-    
+
     @fact Bootstrap.data(bs) --> raw_data ## TODO: define scope
 
     @fact nrun(sampling(bs)) --> n
@@ -35,14 +35,14 @@ function test_bootsample(bs, ref, raw_data, n)
     [@fact straps(bs, i) --> straps(bs)[i]  for i in 1:nvar(bs)]
     [@fact bias(bs, i) --> bias(bs)[i]  for i in 1:nvar(bs)]
     [@fact se(bs, i) --> se(bs)[i]  for i in 1:nvar(bs)]
-    
+
     @fact_throws MethodError model(bs)
-    
+
     return Void
 end
 
 function test_ci(bs)
-    
+
     cim_all = (BasicConfInt(), PercentileConfInt(), NormalConfInt(), BCaConfInt())
     for cim in cim_all
         c = ci(bs, cim)
@@ -66,7 +66,7 @@ city_cor(x::AbstractArray) = cor(x[:,1], x[:,2])
 city_cor(x::AbstractDataFrame) = cor(x[:,:X], x[:,:U])
 
 facts("Basic resampling") do
-    
+
     context("city_ratio with DataFrame input") do
         ref = city_ratio(city)
         @fact ref --> roughly(1.5203125)
@@ -121,9 +121,9 @@ facts("Antithetic resampling") do
     end
 
 end
-    
+
 facts("Balanced resampling") do
-    
+
     context("city_ratio with DataFrame input") do
         ref = city_ratio(city)
         @fact ref --> roughly(1.5203125)
@@ -157,7 +157,7 @@ facts("Balanced resampling") do
     end
 
 end
-    
+
 facts("Exact resampling") do
 
     nc = Bootstrap.nrun_exact(nrow(city))
@@ -178,6 +178,43 @@ facts("Exact resampling") do
         test_ci(bs)
     end
 
+end
+
+facts("Maximum Entropy resampling") do
+    # Simulated AR(1) data copied from
+    # https://github.com/colintbowers/DependentBootstrap.jl/blob/master/test/runtests.jl#L8
+    nobs = 100
+    function test_obs(n, seed=1234)
+        srand(seed)
+        e = randn(n)
+        x = Array{Float64}(n)
+        x[1] = 0.0
+        for i = 2:n
+            x[i] = 0.8 * x[i-1] + e[i]
+        end
+        return sin.(x)
+    end
+
+    r = test_obs(nobs)
+    ref = mean(r)
+    s = MaximumEntropySampling(n)
+    bs = bootstrap(r, mean, s)
+    test_bootsample(bs, ref, r, n)
+    test_ci(bs)
+
+    # Collect the samples
+    samples = zeros(eltype(r), (nobs, n))
+    for i in 1:n
+        # For some reason the samples are only filled in if we have
+        # an explicit assignment back into the matrix.
+        samples[:, i] = draw!(s.cache, r, samples[:, i])
+    end
+
+    # Add some checks to ensure that our within sample variation is greater than our
+    # across sample variation at any given "timestep".
+    @fact all(std(samples, 2) .< std(r)) --> true
+    @fact mean(std(samples, 2)) < 0.1 --> true  # NOTE: This is about 0.09 in julia and 0.08 in the R package
+    @fact std(r) > 0.5 --> true
 end
 
 end


### PR DESCRIPTION
Adds [maximum entropy bootstrapping](https://cran.r-project.org/web/packages/meboot/vignettes/meboot.pdf) for dependent and non-stationary datasets. This implementation is based off [pymeboot](https://github.com/kirajcg/pymeboot) as the original [R package](https://cran.r-project.org/web/packages/meboot/index.html) is GPL licensed.

# Comparison

I've included a few basic tests to catch any serious bugs, but I'll also include a couple plots for visual inspection of some test data. Using the `test_obs` function included in the tests we generated 100 observations as `r`.

## Original R Package

Using RCall we can generate the R output:

```julia
# Assuming meboot is already installed
julia> R"library(meboot)"
WARNING: RCall.jl: Loading required package: dynlm
Loading required package: zoo

Attaching package: ‘zoo’

The following objects are masked from ‘package:base’:

    as.Date, as.Date.numeric

Loading required package: nlme
RCall.RObject{RCall.StrSxp}
 [1] "meboot"    "nlme"      "dynlm"     "zoo"       "stats"     "graphics"
 [7] "grDevices" "utils"     "datasets"  "methods"   "base"

julia> rresp = convert(Array{Float64}, R"meboot($r, reps=250)$ens");
```

![meboot-r](https://user-images.githubusercontent.com/5276097/34446039-acd309d0-ec9d-11e7-8907-776e4c051cbe.png)

## Julia Implementation

Using the Julia implementation:

```julia
s = MaximumEntropySampling(250)
bs = bootstrap(r, mean, s)
samples = zeros(eltype(r), (100, 250))
for i in 1:250
    samples[:, i] = draw!(s.cache, r, samples[:, i])
end
```

![meboot-julia](https://user-images.githubusercontent.com/5276097/34446043-bdf65438-ec9d-11e7-87c2-6ee3e69e04f1.png)
