### PR TITLE
Integrate better with StatsBase function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,27 +82,27 @@ bias and standard error of our statistic.
 
 ```julia
   bias(bs1)
-  se(bs1)
+  stderror(bs1)
 ```
 
-Further, we can estimate confidence intervals for our statistic of interest,
-based on the bootstrapped samples.
+Furthermore, we can estimate confidence intervals (CIs) for our statistic of
+interest, based on the bootstrapped samples.
 
 ```julia
   ## calculate 95% confidence intervals
   cil = 0.95;
 
   ## basic CI
-  bci1 = ci(bs1, BasicConfInt(cil));
+  bci1 = confint(bs1, BasicConfInt(cil));
 
   ## percentile CI
-  bci2 = ci(bs1, PercentileConfInt(cil));
+  bci2 = confint(bs1, PercentileConfInt(cil));
 
   ## BCa CI
-  bci3 = ci(bs1, BCaConfInt(cil));
+  bci3 = confint(bs1, BCaConfInt(cil));
 
   ## Normal CI
-  bci4 = ci(bs1, NormalConfInt(cil));
+  bci4 = confint(bs1, NormalConfInt(cil));
 ```
 
 

--- a/src/Bootstrap.jl
+++ b/src/Bootstrap.jl
@@ -13,6 +13,7 @@ using DataFrames
 using StatsModels
 
 import Base: start, next, done, eltype, length
+import StatsBase: confint, stderror
 
 export
     Model,
@@ -41,8 +42,8 @@ export
     sampling,
     noise,
     bias,
-    se,
-    ci,
+    stderror,
+    confint,
     BasicConfInt,
     PercentileConfInt,
     NormalConfInt,
@@ -58,5 +59,6 @@ include("get.jl")
 include("show.jl")
 include("confint.jl")
 include("datasets/Datasets.jl")
+include("deprecates.jl")
 
 end

--- a/src/confint.jl
+++ b/src/confint.jl
@@ -78,12 +78,12 @@ StudentConfInt() = StudentConfInt(_level)
 
 level(cim::ConfIntMethod) = cim.level
 
-function ci(bs::BootstrapSample, cim::ConfIntMethod)
-    tuple([ci(bs, cim, i) for i in 1:nvar(bs)]...)
+function confint(bs::BootstrapSample, cim::ConfIntMethod)
+    tuple([confint(bs, cim, i) for i in 1:nvar(bs)]...)
 end
 
 ## basic
-function ci(bs::BootstrapSample, cim::BasicConfInt, i::Int)
+function confint(bs::BootstrapSample, cim::BasicConfInt, i::Int)
     l = level(cim)
     t0 = original(bs, i)
     t1 = straps(bs, i)
@@ -93,7 +93,7 @@ function ci(bs::BootstrapSample, cim::BasicConfInt, i::Int)
 end
 
 ## percentile
-function ci(bs::BootstrapSample, cim::PercentileConfInt, i::Int)
+function confint(bs::BootstrapSample, cim::PercentileConfInt, i::Int)
     l = level(cim)
     t0 = original(bs, i)
     t1 = straps(bs, i)
@@ -103,18 +103,18 @@ function ci(bs::BootstrapSample, cim::PercentileConfInt, i::Int)
 end
 
 ## normal
-function ci(bs::BootstrapSample, cim::NormalConfInt, i::Int)
+function confint(bs::BootstrapSample, cim::NormalConfInt, i::Int)
     l = level(cim)
     t0 = original(bs, i)
     t0b = t0 - bias(bs, i)
-    merr = se(bs, i) * quantile(Normal(), (1+l)/2)
+    merr = stderror(bs, i) * quantile(Normal(), (1+l)/2)
     lower = t0b - merr
     upper = t0b + merr
     return t0, lower, upper
 end
 
 ## BCa
-function ci(bs::BootstrapSample, cim::BCaConfInt, i::Int)
+function confint(bs::BootstrapSample, cim::BCaConfInt, i::Int)
     l = level(cim)
     t0 = original(bs, i)
     t1 = straps(bs, i)
@@ -133,11 +133,11 @@ end
 
 
 ## student
-function ci(bs::BootstrapSample, sd1::AbstractVector{Float64}, cim::StudentConfInt, i::Int)
+function confint(bs::BootstrapSample, sd1::AbstractVector{Float64}, cim::StudentConfInt, i::Int)
     l = level(cim)
     t0 = original(bs, i)
     t1 = straps(bs, i)
-    t0se = se(bs, i)
+    t0se = stderror(bs, i)
     z = (t1 - t0) ./ sd1
     alpha = ([l, -l] + 1.)/2.
     lower, upper = t0 - t0se .* quantile(z, alpha)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,0 +1,12 @@
+import Base.@deprecate
+import Base.depwarn
+
+# ci -> confint
+@deprecate ci(bs::BootstrapSample, cim::T) where T<:ConfIntMethod confint(bs, cim)
+@deprecate ci(bs::BootstrapSample, cim::T, i::Int) where T<:ConfIntMethod confint(bs, cim, i)
+@deprecate ci(bs::BootstrapSample, sd::AbstractVector, cim::T, i::Int) where T<:ConfIntMethod confint(bs, sd, cim, i)
+
+# se -> stderror
+@deprecate se(x::AbstractVector) stderror(x)
+@deprecate se(bs::BootstrapSample) stderror(bs)
+@deprecate se(bs::BootstrapSample, idx::Int) stderror(bs, idx)

--- a/src/get.jl
+++ b/src/get.jl
@@ -20,15 +20,15 @@ Estimate the standard error of a bootstrap sampling.
 ```julia
 bs = bootstrap(randn(20), mean, BasicSampling(100))
 
-se(bs)
+stderror(bs)
 ```
 
 """
-se(t1::AbstractVector) = std(t1)
+stderror(t1::AbstractVector) = std(t1)
 
-se(bs::BootstrapSample) = [se(t1) for t1 in straps(bs)]
+stderror(bs::BootstrapSample) = [stderror(t1) for t1 in straps(bs)]
 
-se(bs::BootstrapSample, idx::Int) = se(straps(bs, idx))
+stderror(bs::BootstrapSample, idx::Int) = stderror(straps(bs, idx))
 
 
 original(bs::BootstrapSample) = bs.t0

--- a/src/show.jl
+++ b/src/show.jl
@@ -35,6 +35,6 @@ function estimate_summary(bs::BootstrapSample)
     n = nvar(bs)
     df = DataFrame(Estimate = [original(bs)...],
                    Bias = bias(bs),
-                   StdError = se(bs))
+                   StdError = stderror(bs))
     return df
 end

--- a/test/test-bootsample-non-parametric.jl
+++ b/test/test-bootsample-non-parametric.jl
@@ -31,24 +31,24 @@ using StatsBase
 
         @test length(bias(bs)) == length(ref)
         [@test (b[1] > -Inf && b[1] < Inf) for b in bias(bs)]
-        @test length(se(bs)) == length(ref)
-        [@test s >= 0 for s in se(bs)]
+        @test length(stderror(bs)) == length(ref)
+        [@test s >= 0 for s in stderror(bs)]
 
         [@test original(bs, i) == original(bs)[i]  for i in 1:nvar(bs)]
         [@test straps(bs, i) == straps(bs)[i]  for i in 1:nvar(bs)]
         [@test bias(bs, i) == bias(bs)[i]  for i in 1:nvar(bs)]
-        [@test se(bs, i) == se(bs)[i]  for i in 1:nvar(bs)]
+        [@test stderror(bs, i) == stderror(bs)[i]  for i in 1:nvar(bs)]
 
         @test_throws MethodError model(bs)
 
         return Void
     end
 
-    function test_ci(bs)
+    function test_confint(bs)
 
         cim_all = (BasicConfInt(), PercentileConfInt(), NormalConfInt(), BCaConfInt())
         for cim in cim_all
-            c = ci(bs, cim)
+            c = confint(bs, cim)
             [@test (x[1] >= x[2]  && x[1] <= x[3]) for x in c]
             [@test x[1] ≈ t0 for (x, t0) in zip(c, original(bs))]
             @test level(cim) == 0.95
@@ -76,21 +76,21 @@ using StatsBase
             @test ref  ≈ 1.5203125
             bs = bootstrap(city, city_ratio, BasicSampling(n))
             test_bootsample(bs, ref, city, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "city_cor with DataFrame input" begin
             ref = city_cor(city)
             bs = bootstrap(city, city_cor, BasicSampling(n))
             test_bootsample(bs, ref, city, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "city_cor with DataArray input" begin
             ref = city_cor(citya)
             bs = bootstrap(citya, city_cor, BasicSampling(n))
             test_bootsample(bs, ref, citya, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "mean_and_sd: Vector input, 2 output variables" begin
@@ -98,7 +98,7 @@ using StatsBase
             ref = mean_and_std(r)
             bs = bootstrap(r, mean_and_std, BasicSampling(n))
             test_bootsample(bs, ref, r, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "mean_and_sd: Student CI" begin
@@ -106,7 +106,7 @@ using StatsBase
             bs = bootstrap(r, mean_and_std, BasicSampling(n))
             ## Student confint
             cim = StudentConfInt()
-            c = ci(bs, straps(bs, 2), cim, 1)
+            c = confint(bs, straps(bs, 2), cim, 1)
             @test c[1] >= c[2]  && c[1] <= c[3]
             @test c[1] ≈ original(bs, 1)
             @test level(cim) == 0.95
@@ -121,7 +121,7 @@ using StatsBase
             ref = mean_and_std(r)
             bs = bootstrap(r, mean_and_std, AntitheticSampling(n))
             test_bootsample(bs, ref, r, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
     end
@@ -133,21 +133,21 @@ using StatsBase
             @test ref ≈ 1.5203125
             bs = bootstrap(city, city_ratio, BalancedSampling(n))
             test_bootsample(bs, ref, city, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "city_cor with DataFrame input" begin
             ref = city_cor(city)
             bs = bootstrap(city, city_cor, BalancedSampling(n))
             test_bootsample(bs, ref, city, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "city_cor with DataArray input" begin
             ref = city_cor(citya)
             bs = bootstrap(citya, city_cor, BalancedSampling(n))
             test_bootsample(bs, ref, citya, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "mean_and_sd: Vector input, 2 output variables" begin
@@ -155,7 +155,7 @@ using StatsBase
             ref = mean_and_std(r)
             bs = bootstrap(r, mean_and_std, BalancedSampling(n))
             test_bootsample(bs, ref, r, n)
-            test_ci(bs)
+            test_confint(bs)
             ## mean should be unbiased
             @test isapprox( bias(bs)[1], 0.0, atol = 1e-8 )
         end
@@ -171,7 +171,7 @@ using StatsBase
             @test ref ≈ 1.5203125
             bs = bootstrap(city, city_ratio, ExactSampling())
             test_bootsample(bs, ref, city, nc)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "mean: Vector input, 1 output variables" begin
@@ -179,7 +179,7 @@ using StatsBase
             ref = mean(r)
             bs = bootstrap(r, mean, ExactSampling())
             test_bootsample(bs, ref, r, nc)
-            test_ci(bs)
+            test_confint(bs)
         end
 
     end
@@ -207,7 +207,7 @@ using StatsBase
         s = MaximumEntropySampling(n)
         bs = bootstrap(r, mean, s)
         test_bootsample(bs, ref, r, n)
-        test_ci(bs)
+        test_confint(bs)
 
         # Collect the samples
         samples = zeros(eltype(r), (nobs, n))

--- a/test/test-bootsample-parametric.jl
+++ b/test/test-bootsample-parametric.jl
@@ -33,13 +33,13 @@ using Distributions
 
         @test length(bias(bs)) == length(ref)
         [@test (b[1] > -Inf && b[1] < Inf) for b in bias(bs)]
-        @test length(se(bs)) == length(ref)
-        [@test s >= 0 for s in se(bs)]
+        @test length(stderror(bs)) == length(ref)
+        [@test s >= 0 for s in stderror(bs)]
 
         [@test original(bs, i) == original(bs)[i]  for i in 1:nvar(bs)]
         [@test straps(bs, i) == straps(bs)[i]  for i in 1:nvar(bs)]
         [@test bias(bs, i) == bias(bs)[i]  for i in 1:nvar(bs)]
-        [@test se(bs, i) == se(bs)[i]  for i in 1:nvar(bs)]
+        [@test stderror(bs, i) == stderror(bs)[i]  for i in 1:nvar(bs)]
 
         m = model(bs)
         @test issubtype(typeof(m), Bootstrap.Model)
@@ -47,11 +47,11 @@ using Distributions
         return Void
     end
 
-    function test_ci(bs)
+    function test_confint(bs)
 
         cim_all = (BasicConfInt(), PercentileConfInt(), NormalConfInt(), BCaConfInt())
         for cim in cim_all
-            c = ci(bs, cim)
+            c = confint(bs, cim)
             [@test (x[1] >= x[2]  && x[1] <= x[3]) for x in c]
             [@test x[1] ≈ t0 for (x, t0) in zip(c, original(bs))]
         end
@@ -74,13 +74,13 @@ using Distributions
         @testset "Basic resampling: Normal distribution" begin
             bs = bootstrap(r, mean, Model(Normal), BasicSampling(n))
             test_bootsample(bs, ref, r, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "Balanced resampling: Normal distribution" begin
             bs = bootstrap(r, mean, Model(Normal), BalancedSampling(n))
             test_bootsample(bs, ref, r, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         ref = mean(fit(Exponential, aircondit))
@@ -88,13 +88,13 @@ using Distributions
         @testset "Basic resampling: Exponential distribution" begin
             bs = bootstrap(aircondit, mean, Model(Exponential), BasicSampling(n))
             test_bootsample(bs, ref, aircondit, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
         @testset "Balanced resampling: Exponential distribution" begin
             bs = bootstrap(aircondit, mean, Model(Exponential), BalancedSampling(n))
             test_bootsample(bs, ref, aircondit, n)
-            test_ci(bs)
+            test_confint(bs)
         end
 
     end


### PR DESCRIPTION
Integrates with the naming of the equivalent functions in `StatsBase.jl`:  Renames `ci` to `confint` and `se` to `stderror`. The old function names have been deprecated, and will be supported until the next major release. The motivation for these change is outlined in #23.