### PR TITLE
Put the function argument first in the signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ More elaborate cases are covered in the documentation notebooks.
   using Bootstrap
 ```
 
-Our observations `r` are sampled from a standard normal distribution.
+Our observations in `some_data` are sampled from a standard normal distribution.
 
 ```julia
-  r = randn(100);
+  some_data = randn(100);
 ```
 
 Let's bootstrap the standard deviation (`std`) of our data, based on 1000
@@ -71,14 +71,14 @@ resamples and with different bootstrapping approaches.
   n_boot = 1000
 
   ## basic bootstrap
-  bs1 = bootstrap(r, std, BasicSampling(n_boot))
+  bs1 = bootstrap(std, some_data, BasicSampling(n_boot))
 
   ## balanced bootstrap
-  bs2 = bootstrap(r, std, BalancedSampling(n_boot))
+  bs2 = bootstrap(std, some_data, BalancedSampling(n_boot))
 ```
 
-We can explore the properties of the bootstrapped samples, for example estimated
-bias and standard error of our statistic.
+We can explore the properties of the bootstrapped samples, for example, the
+estimated bias and standard error of our statistic.
 
 ```julia
   bias(bs1)

--- a/src/bootsampling.jl
+++ b/src/bootsampling.jl
@@ -185,9 +185,9 @@ zeros_tuple(t, n) = tuple([zeros(typeof(x), n) for x in t]...)
 lhs(f::Formula) = f.lhs
 
 """
-bootstrap(data, statistic, BasicSampling())
+bootstrap(statistic, data, BasicSampling())
 """
-function bootstrap(data, statistic::Function, sampling::BasicSampling)
+function bootstrap(statistic::Function, data, sampling::BasicSampling)
     t0 = tx(statistic(data))
     m = nrun(sampling)
     t1 = zeros_tuple(t0, m)
@@ -203,9 +203,9 @@ end
 
 
 """
-bootstrap(data, statistic, AntitheticSampling)
+bootstrap(statistic, data, AntitheticSampling)
 """
-function bootstrap(data::AbstractVector, statistic::Function, sampling::AntitheticSampling)
+function bootstrap(statistic::Function, data::AbstractVector, sampling::AntitheticSampling)
     t0 = tx(statistic(data))
     m = nrun(sampling)
     n = nobs(data)
@@ -232,9 +232,9 @@ end
 
 
 """
-bootstrap(data, statistic, sampling)
+bootstrap(statistic, data, sampling)
 """
-function bootstrap(data, statistic::Function, sampling::BalancedSampling)
+function bootstrap(statistic::Function, data, sampling::BalancedSampling)
     n = nobs(data)
     m = nrun(sampling)
     t0 = tx(statistic(data))
@@ -282,9 +282,9 @@ eltype{T}(itr::ExactIterator{Range{T}}) = Array{T, 1}
 length(itr::ExactIterator) = binomial(length(itr.a) + itr.k - 1, itr.k)
 
 """
-bootstrap(data, statistic, sampling)
+bootstrap(statistic, data, sampling)
 """
-function bootstrap(data, statistic::Function, sampling::ExactSampling)
+function bootstrap(statistic::Function, data, sampling::ExactSampling)
     n = nobs(data)
     m = nrun_exact(n)
     t0 = tx(statistic(data))
@@ -299,9 +299,9 @@ function bootstrap(data, statistic::Function, sampling::ExactSampling)
 end
 
 """
-bootstrap(data, statistic, MaximumEntropySampling)
+bootstrap(statistic, data, MaximumEntropySampling)
 """
-function bootstrap(data, statistic::Function, sampling::MaximumEntropySampling)
+function bootstrap(statistic::Function, data, sampling::MaximumEntropySampling)
     init!(sampling.cache, data)
 
     t0 = tx(statistic(data))
@@ -318,9 +318,9 @@ function bootstrap(data, statistic::Function, sampling::MaximumEntropySampling)
 end
 
 """
-bootstrap(data, statistic, model, sampling)
+bootstrap(statistic, data, model, sampling)
 """
-function bootstrap(data, statistic::Function, model::SimpleModel, sampling::BootstrapSampling)
+function bootstrap(statistic::Function, data, model::SimpleModel, sampling::BootstrapSampling)
     f0 = fit(model.class, data, model.args...; model.kwargs...)
     t0 = tx(statistic(data))
     m = nrun(sampling)
@@ -337,9 +337,9 @@ end
 
 
 """
-bootstrap(data, statistic, model, formula, sampling)
+bootstrap(statistic, data, model, formula, sampling)
 """
-function bootstrap(data::AbstractDataFrame, statistic::Function, model::FormulaModel, sampling::ResidualSampling)
+function bootstrap(statistic::Function, data::AbstractDataFrame, model::FormulaModel, sampling::ResidualSampling)
     class = model.class
     formula = model.formula
     args = model.args
@@ -366,9 +366,9 @@ end
 
 
 """
-bootstrap(data, statistic, model, formula, Wildsampling(nrun, noise))
+bootstrap(statistic, data, model, formula, Wildsampling(nrun, noise))
 """
-function bootstrap(data::AbstractDataFrame, statistic::Function, model::FormulaModel, sampling::WildSampling)
+function bootstrap(statistic::Function, data::AbstractDataFrame, model::FormulaModel, sampling::WildSampling)
     class = model.class
     formula = model.formula
     args = model.args

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -10,3 +10,7 @@ import Base.depwarn
 @deprecate se(x::AbstractVector) stderror(x)
 @deprecate se(bs::BootstrapSample) stderror(bs)
 @deprecate se(bs::BootstrapSample, idx::Int) stderror(bs, idx)
+
+# functions before data
+@deprecate bootstrap(data, statistic::Function, sampling::Sampling) where Sampling<:BootstrapSampling bootstrap(statistic, data, sampling)
+@deprecate bootstrap(data, statistic::Function, model, sampling::Sampling) where Sampling<:BootstrapSampling bootstrap(statistic, data, model, sampling)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -2,9 +2,9 @@ import Base.@deprecate
 import Base.depwarn
 
 # ci -> confint
-@deprecate ci(bs::BootstrapSample, cim::T) where T<:ConfIntMethod confint(bs, cim)
-@deprecate ci(bs::BootstrapSample, cim::T, i::Int) where T<:ConfIntMethod confint(bs, cim, i)
-@deprecate ci(bs::BootstrapSample, sd::AbstractVector, cim::T, i::Int) where T<:ConfIntMethod confint(bs, sd, cim, i)
+@deprecate ci(bs::BootstrapSample, cim::ConfIntMethod) confint(bs, cim)
+@deprecate ci(bs::BootstrapSample, cim::ConfIntMethod, i::Int) confint(bs, cim, i)
+@deprecate ci(bs::BootstrapSample, sd::AbstractVector, cim::ConfIntMethod, i::Int) confint(bs, sd, cim, i)
 
 # se -> stderror
 @deprecate se(x::AbstractVector) stderror(x)
@@ -12,5 +12,5 @@ import Base.depwarn
 @deprecate se(bs::BootstrapSample, idx::Int) stderror(bs, idx)
 
 # functions before data
-@deprecate bootstrap(data, statistic::Function, sampling::Sampling) where Sampling<:BootstrapSampling bootstrap(statistic, data, sampling)
-@deprecate bootstrap(data, statistic::Function, model, sampling::Sampling) where Sampling<:BootstrapSampling bootstrap(statistic, data, model, sampling)
+@deprecate bootstrap(data, statistic::Function, sampling::BootstrapSampling) bootstrap(statistic, data, sampling)
+@deprecate bootstrap(data, statistic::Function, model, sampling::BootstrapSampling) bootstrap(statistic, data, model, sampling)

--- a/src/get.jl
+++ b/src/get.jl
@@ -2,7 +2,7 @@
 Estimate the bias of a bootstrap sampling.
 
 ```julia
-bs = bootstrap(randn(20), mean, BasicSampling(100))
+bs = bootstrap(mean, randn(20), BasicSampling(100))
 
 bias(bs)
 ```
@@ -18,7 +18,7 @@ bias(bs::BootstrapSample, idx::Int) = bias(original(bs, idx), straps(bs, idx))
 Estimate the standard error of a bootstrap sampling.
 
 ```julia
-bs = bootstrap(randn(20), mean, BasicSampling(100))
+bs = bootstrap(mean, randn(20), BasicSampling(100))
 
 stderror(bs)
 ```

--- a/test/test-bootsample-non-parametric.jl
+++ b/test/test-bootsample-non-parametric.jl
@@ -74,21 +74,21 @@ using StatsBase
         @testset "city_ratio with DataFrame input" begin
             ref = city_ratio(city)
             @test ref  ≈ 1.5203125
-            bs = bootstrap(city, city_ratio, BasicSampling(n))
+            bs = bootstrap(city_ratio, city, BasicSampling(n))
             test_bootsample(bs, ref, city, n)
             test_confint(bs)
         end
 
         @testset "city_cor with DataFrame input" begin
             ref = city_cor(city)
-            bs = bootstrap(city, city_cor, BasicSampling(n))
+            bs = bootstrap(city_cor, city, BasicSampling(n))
             test_bootsample(bs, ref, city, n)
             test_confint(bs)
         end
 
         @testset "city_cor with DataArray input" begin
             ref = city_cor(citya)
-            bs = bootstrap(citya, city_cor, BasicSampling(n))
+            bs = bootstrap(city_cor, citya, BasicSampling(n))
             test_bootsample(bs, ref, citya, n)
             test_confint(bs)
         end
@@ -96,14 +96,14 @@ using StatsBase
         @testset "mean_and_sd: Vector input, 2 output variables" begin
             r = randn(25)
             ref = mean_and_std(r)
-            bs = bootstrap(r, mean_and_std, BasicSampling(n))
+            bs = bootstrap(mean_and_std, r, BasicSampling(n))
             test_bootsample(bs, ref, r, n)
             test_confint(bs)
         end
 
         @testset "mean_and_sd: Student CI" begin
             r = randn(25)
-            bs = bootstrap(r, mean_and_std, BasicSampling(n))
+            bs = bootstrap(mean_and_std, r, BasicSampling(n))
             ## Student confint
             cim = StudentConfInt()
             c = confint(bs, straps(bs, 2), cim, 1)
@@ -119,7 +119,7 @@ using StatsBase
         @testset "mean_and_sd: Vector input, 2 output variables" begin
             r = randn(50)
             ref = mean_and_std(r)
-            bs = bootstrap(r, mean_and_std, AntitheticSampling(n))
+            bs = bootstrap(mean_and_std, r, AntitheticSampling(n))
             test_bootsample(bs, ref, r, n)
             test_confint(bs)
         end
@@ -131,21 +131,21 @@ using StatsBase
         @testset "city_ratio with DataFrame input" begin
             ref = city_ratio(city)
             @test ref ≈ 1.5203125
-            bs = bootstrap(city, city_ratio, BalancedSampling(n))
+            bs = bootstrap(city_ratio, city, BalancedSampling(n))
             test_bootsample(bs, ref, city, n)
             test_confint(bs)
         end
 
         @testset "city_cor with DataFrame input" begin
             ref = city_cor(city)
-            bs = bootstrap(city, city_cor, BalancedSampling(n))
+            bs = bootstrap(city_cor, city, BalancedSampling(n))
             test_bootsample(bs, ref, city, n)
             test_confint(bs)
         end
 
         @testset "city_cor with DataArray input" begin
             ref = city_cor(citya)
-            bs = bootstrap(citya, city_cor, BalancedSampling(n))
+            bs = bootstrap(city_cor, citya, BalancedSampling(n))
             test_bootsample(bs, ref, citya, n)
             test_confint(bs)
         end
@@ -153,7 +153,7 @@ using StatsBase
         @testset "mean_and_sd: Vector input, 2 output variables" begin
             r = randn(50)
             ref = mean_and_std(r)
-            bs = bootstrap(r, mean_and_std, BalancedSampling(n))
+            bs = bootstrap(mean_and_std, r, BalancedSampling(n))
             test_bootsample(bs, ref, r, n)
             test_confint(bs)
             ## mean should be unbiased
@@ -169,7 +169,7 @@ using StatsBase
         @testset "city_ratio with DataFrame input" begin
             ref = city_ratio(city)
             @test ref ≈ 1.5203125
-            bs = bootstrap(city, city_ratio, ExactSampling())
+            bs = bootstrap(city_ratio, city, ExactSampling())
             test_bootsample(bs, ref, city, nc)
             test_confint(bs)
         end
@@ -177,7 +177,7 @@ using StatsBase
         @testset "mean: Vector input, 1 output variables" begin
             r = randn(10)
             ref = mean(r)
-            bs = bootstrap(r, mean, ExactSampling())
+            bs = bootstrap(mean, r, ExactSampling())
             test_bootsample(bs, ref, r, nc)
             test_confint(bs)
         end
@@ -205,7 +205,7 @@ using StatsBase
         r = test_obs(nobs)
         ref = mean(r)
         s = MaximumEntropySampling(n)
-        bs = bootstrap(r, mean, s)
+        bs = bootstrap(mean, r, s)
         test_bootsample(bs, ref, r, n)
         test_confint(bs)
 

--- a/test/test-bootsample-parametric.jl
+++ b/test/test-bootsample-parametric.jl
@@ -72,13 +72,13 @@ using Distributions
         ref = mean(r)
 
         @testset "Basic resampling: Normal distribution" begin
-            bs = bootstrap(r, mean, Model(Normal), BasicSampling(n))
+            bs = bootstrap(mean, r, Model(Normal), BasicSampling(n))
             test_bootsample(bs, ref, r, n)
             test_confint(bs)
         end
 
         @testset "Balanced resampling: Normal distribution" begin
-            bs = bootstrap(r, mean, Model(Normal), BalancedSampling(n))
+            bs = bootstrap(mean, r, Model(Normal), BalancedSampling(n))
             test_bootsample(bs, ref, r, n)
             test_confint(bs)
         end
@@ -86,13 +86,13 @@ using Distributions
         ref = mean(fit(Exponential, aircondit))
 
         @testset "Basic resampling: Exponential distribution" begin
-            bs = bootstrap(aircondit, mean, Model(Exponential), BasicSampling(n))
+            bs = bootstrap(mean, aircondit, Model(Exponential), BasicSampling(n))
             test_bootsample(bs, ref, aircondit, n)
             test_confint(bs)
         end
 
         @testset "Balanced resampling: Exponential distribution" begin
-            bs = bootstrap(aircondit, mean, Model(Exponential), BalancedSampling(n))
+            bs = bootstrap(mean, aircondit, Model(Exponential), BalancedSampling(n))
             test_bootsample(bs, ref, aircondit, n)
             test_confint(bs)
         end
@@ -104,18 +104,18 @@ using Distributions
         ref = coef(fit(LinearModel, @formula(thirty ~ twenty), city2))
 
         @testset "Residual resampling" begin
-            bs = bootstrap(city2, coef, Model(LinearModel, @formula(thirty ~ twenty)), ResidualSampling(n))
+            bs = bootstrap(coef, city2, Model(LinearModel, @formula(thirty ~ twenty)), ResidualSampling(n))
             test_bootsample(bs, ref, city2, n)
         end
 
         @testset "Wild resampling: Rademacher" begin
-            bs = bootstrap(city2, coef, Model(LinearModel, @formula(thirty ~ twenty)), WildSampling(n, rademacher))
+            bs = bootstrap(coef, city2, Model(LinearModel, @formula(thirty ~ twenty)), WildSampling(n, rademacher))
             test_bootsample(bs, ref, city2, n)
             @test isa( noise(sampling(bs)), Function )
         end
 
         @testset "Wild resampling: Mammen" begin
-            bs = bootstrap(city2, coef, Model(LinearModel, @formula(thirty ~ twenty)), WildSampling(n, mammen))
+            bs = bootstrap(coef, city2, Model(LinearModel, @formula(thirty ~ twenty)), WildSampling(n, mammen))
             test_bootsample(bs, ref, city2, n)
             @test isa( noise(sampling(bs)), Function )
         end
@@ -129,21 +129,21 @@ using Distributions
         conv_tol = 1e-3
 
         @testset "Residual resampling" begin
-            bs = bootstrap(city2, coef,
+            bs = bootstrap(coef, city2,
                            Model(GeneralizedLinearModel, @formula(thirty ~ twenty), Normal(), maxIter = max_iter, convTol = conv_tol),
                            ResidualSampling(n))
             test_bootsample(bs, ref, city2, n)
         end
 
         @testset "Residual resampling with link function" begin
-            bs = bootstrap(city2, coef,
+            bs = bootstrap(coef, city2,
                            Model(GeneralizedLinearModel, @formula(thirty ~ twenty), Normal(), IdentityLink(), maxIter = max_iter, convTol = conv_tol),
                            ResidualSampling(n))
             test_bootsample(bs, ref, city2, n)
         end
 
         @testset "Wild resampling: Rademacher" begin
-            bs = bootstrap(city2, coef,
+            bs = bootstrap(coef, city2,
                            Model(GeneralizedLinearModel, @formula(thirty ~ twenty), Normal(), maxIter = max_iter, convTol = conv_tol),
                            WildSampling(n, rademacher))
             test_bootsample(bs, ref, city2, n)
@@ -151,7 +151,7 @@ using Distributions
         end
 
         @testset "Wild resampling with link function: Mammen" begin
-            bs = bootstrap(city2, coef,
+            bs = bootstrap(coef, city2,
                            Model(GeneralizedLinearModel, @formula(thirty ~ twenty), Normal(), IdentityLink(), maxIter = max_iter, convTol = conv_tol),
                            WildSampling(n, mammen))
             test_bootsample(bs, ref, city2, n)


### PR DESCRIPTION
Changes the `bootstrap` signature to have the function argument come first:

```
bootstrap(statistic::Function, data, sampling)
```
instead of
```
bootstrap(data, statistic::Function, sampling)
```

This adopts the new julia style and was suggested by @ararslan in #22. The old syntax has been deprecated, and will be supported until the next major release.