### PR TITLE
Update and pin dependencies for v2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ notifications:
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder(), flags="julia_$(VERSION.major)_$(VERSION.minor)")'
-  - julia -e 'using Pkg; Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); include(joinpath("docs", "make.jl"))'
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,8 @@
 The Bootstrap.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2014-2018: Julian Gehring, Nikolaos Ignatiadis.
+> Copyright (c) 2014-2019: Julian Gehring.
+>
+> Copyright (c) 2014-2016: Nikolaos Ignatiadis.
 >
 > Copyright (c) 2014: Jarno Leppänen.
 >

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Bootstrap.jl News and Changes
 
+## Version 2.0.1
+
+### Changes
+
+- Fix `Documenter` version to v0.19 for building the documentation (#35)
+- Fix `convert` deprecation in `DataFrames`, bump required version to v0.16.0
+
+
 ## Version 2.0.0
 
 ### Interface changes

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.7
 StatsBase 0.24.0
 Distributions 0.16.1
-DataFrames 0.14.0
+DataFrames 0.16.0
 StatsModels 0.2.0

--- a/test/test-bootsample-non-parametric.jl
+++ b/test/test-bootsample-non-parametric.jl
@@ -63,7 +63,7 @@ using StatsBase
     n = 250
 
     ## 'city' dataset
-    citya = convert(Array, city)
+    citya = convert(Matrix, city)
 
     city_ratio(x::AbstractArray) = mean(x[:,2]) ./ mean(x[:,1])
     city_ratio(x::AbstractDataFrame) = mean(x[:X]) ./ mean(x[:U])


### PR DESCRIPTION
- Fix `Documenter` version to v0.19 for building the documentation (#35)
- Fix `convert` deprecation in `DataFrames`, bump required version to v0.16.0