### PR TITLE
Add StatsModels compatibility and remove REQUIRE

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,6 @@ name = "Bootstrap"
 uuid = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"
 version = "2.0.1+"
 
-
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -10,6 +9,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+
+[compat]
+StatsModels = "0.5.0"
 
 [extras]
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 1.0
-StatsBase 0.24.0
-Distributions 0.16.1
-DataFrames 0.16.0
-StatsModels 0.3.0


### PR DESCRIPTION
Removed deprecated REQUIRE file.

Added a compatibility for StatsModels to version 0.5.0 until Bootstrap can be updated against newest release of StatsModels (0.6.0).

This address comments in #52