### PR TITLE
WIP: possible solution to allow bootstrapping form an arbitrary number of distributions

### DIFF
--- a/src/bootsampling.jl
+++ b/src/bootsampling.jl
@@ -187,18 +187,22 @@ lhs(f::Formula) = f.lhs
 """
 bootstrap(statistic, data, BasicSampling())
 """
-function bootstrap(statistic::Function, data, sampling::BasicSampling)
-    t0 = tx(statistic(data))
+function bootstrap(statistic::Function, data::Tuple, sampling::BasicSampling)
+    t0 = tx(statistic(data...))
     m = nrun(sampling)
     t1 = zeros_tuple(t0, m)
-    data1 = copy(data)
+    data1 = copy.(data)
     for i in 1:m
-        draw!(data, data1)
-        for (j, t) in enumerate(tx(statistic(data1)))
+        draw!.(data, data1)
+        for (j, t) in enumerate(tx(statistic(data1...)))
             t1[j][i] = t
         end
     end
     return NonParametricBootstrapSample(t0, t1, statistic, data, sampling)
+end
+
+function bootstrap(statistic::Function, data, sampling::BasicSampling)
+    bootstrap(statistic, (data,), sampling)
 end
 
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -30,6 +30,9 @@ function data_summary(x)
     return s
 end
 
+# TEMP hack to get `Base.show` to work on a `Tuple`
+data_summary(x::Tuple) = ""
+
 
 function estimate_summary(bs::BootstrapSample)
     n = nvar(bs)


### PR DESCRIPTION
This is one possible way to implement #51. Essentially we redefine the `bootstrap` method, that contains the main logic, to accept a tuple and then define a separate method that wraps any non-tuple input in a tuple. Currently this is a prototype and is only implemented for `BasicSampling`. This allows the following:

```julia
julia> using Bootstrap, Statistics

julia> xs = rand(1000);

julia> ys = rand(1000) .+ .5;

julia> bootstrap((x,y)->mean(x)-mean(y), (xs, ys), BasicSampling(1000))
Bootstrap Sampling
  Estimates:
    │ Var │ Estimate  │ Bias        │ StdError  │
    │     │ Float64   │ Float64     │ Float64   │
    ├─────┼───────────┼─────────────┼───────────┤
    │ 1   │ -0.507899 │ -7.02681e-5 │ 0.0124963 │
  Sampling: BasicSampling
  Samples:  1000
  Data:  

```

Would be interested in your thoughts!