### PR TITLE
Remove abstract fields

### DIFF
--- a/src/confint.jl
+++ b/src/confint.jl
@@ -10,8 +10,8 @@ BasicConfInt(0.95)
 ```
 
 """
-struct BasicConfInt <: ConfIntMethod
-    level::AbstractFloat
+struct BasicConfInt{T} <: ConfIntMethod
+    level::T
 end
 
 BasicConfInt() = BasicConfInt(_level)
@@ -25,14 +25,14 @@ PercentileConfInt(0.95)
 ```
 
 """
-struct PercentileConfInt <: ConfIntMethod
-    level::AbstractFloat
+struct PercentileConfInt{T} <: ConfIntMethod
+    level::T
 end
 
 PercentileConfInt() = PercentileConfInt(_level)
 
-struct NormalConfInt <: ConfIntMethod
-    level::AbstractFloat
+struct NormalConfInt{T} <: ConfIntMethod
+    level::T
 end
 
 
@@ -46,8 +46,8 @@ NormalConfInt(0.95)
 """
 NormalConfInt() = NormalConfInt(_level)
 
-struct BCaConfInt <: ConfIntMethod
-    level::AbstractFloat
+struct BCaConfInt{T} <: ConfIntMethod
+    level::T
 end
 
 
@@ -61,8 +61,8 @@ BCaConfInt(0.95)
 """
 BCaConfInt() = BCaConfInt(_level)
 
-struct StudentConfInt <: ConfIntMethod
-    level::AbstractFloat
+struct StudentConfInt{T} <: ConfIntMethod
+    level::T
 end
 
 """

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -46,7 +46,6 @@ This is intended to minimize memory allocations and time when drawing random sam
 """
 mutable struct MaximumEntropyCache{T <: Real}
     n::Int
-    t::Type{T}
     inds::Vector{Int}
     vals::Vector{T}
     Z::Vector{T}
@@ -58,8 +57,7 @@ mutable struct MaximumEntropyCache{T <: Real}
 end
 
 function MaximumEntropyCache()
-    MaximumEntropyCache{Float64}(0,
-        Float64,
+    MaximumEntropyCache(0,
         Int[],
         Float64[],
         Float64[],
@@ -71,15 +69,14 @@ function MaximumEntropyCache()
     )
 end
 
-function init!(cache::MaximumEntropyCache, x::AbstractArray)
+function init!(cache::MaximumEntropyCache{T}, x::AbstractArray) where T
     cache.n = length(x)
-    cache.t = eltype(x)
     sorted!(cache, x)
     trimmed!(cache, x)
     intermediates!(cache)
     med!(cache)
-    cache.U = zeros(cache.t, cache.n)
-    cache.quantiles = zeros(cache.t, cache.n)
+    cache.U = zeros(T, cache.n)
+    cache.quantiles = zeros(T, cache.n)
     cache.v = [y / cache.n for y in 0:cache.n]
     return nothing
 end
@@ -108,8 +105,8 @@ end
 
 Compute our intermediate points for the ordered values.
 """
-function intermediates!(c::MaximumEntropyCache)
-    c.Z = zeros(c.t, c.n + 1)
+function intermediates!(c::MaximumEntropyCache{T}) where T
+    c.Z = zeros(T, c.n + 1)
     for i in 2:c.n
         c.Z[i] = (c.vals[i - 1] + c.vals[i]) /  2
     end
@@ -125,8 +122,8 @@ end
 Compute the mean of the maximum entropy density within each interval such that
 the ‘mean-preserving constraint’ is satisfied.
 """
-function med!(c::MaximumEntropyCache)
-    c.m = zeros(c.t, c.n)
+function med!(c::MaximumEntropyCache{T}) where T
+    c.m = zeros(T, c.n)
     c.m[1] = 0.75 * c.vals[1] + 0.25 * c.vals[1]
 
     for k in 2:(c.n - 1)


### PR DESCRIPTION
This PR gets rid of the abstract fields by adding type parameters. It is a subset of the changes in https://github.com/juliangehring/Bootstrap.jl/pull/49.

A quick benchmark
```julia
using Bootstrap
using BenchmarkTools                                                                      
using StatsBase                              

function test_mean_and_std(n)                                                             
    r = rand(25)                                                                          
    sampling = BasicSampling(n)

    @btime bootstrap($mean_and_std, $r, $sampling)                                        
end                                          

function test_bca_conf_int(n)                                                             
    sample = bootstrap(mean_and_std, rand(25), BasicSampling(n))                          
    ci = BCaConfInt(0.95)                                                                 

    @btime confint($sample, $ci)
end                     
```
yields on the develop branch
```julia
julia> test_mean_and_std(100); 
  28.043 μs (8 allocations: 2.25 KiB)

julia> test_mean_and_std(1_000);                               
  287.129 μs (8 allocations: 16.38 KiB)      

julia> test_bca_conf_int(100);               
  29.124 μs (347 allocations: 33.13 KiB)     

julia> test_bca_conf_int(1_000);             
  134.613 μs (351 allocations: 47.53 KiB)    
```
and with this PR
```julia
julia> test_mean_and_std(100);     
  25.590 μs (5 allocations: 2.11 KiB)        

julia> test_mean_and_std(1_000);                                                          
  263.614 μs (5 allocations: 16.23 KiB)

julia> test_bca_conf_int(100);              
  12.927 μs (242 allocations: 30.81 KiB)

julia> test_bca_conf_int(1_000); 
  113.563 μs (242 allocations: 45.16 KiB)
```