### PR TITLE
Adjust where clauses

### DIFF
--- a/src/bootsampling.jl
+++ b/src/bootsampling.jl
@@ -343,8 +343,8 @@ struct ResidualTerm{S,T,R} <: StatsModels.AbstractTerm
 end
 
 
-StatsModels.modelcols(t::ResidualTerm{S}, data) where {S} =
-    throw(ArgumentError("ResidualTerm: don't know how to generate model columns for $S"))
+StatsModels.modelcols(t::ResidualTerm, data) =
+    throw(ArgumentError("ResidualTerm: don't know how to generate model columns for $(typeof(t.sampling))"))
 StatsModels.modelcols(t::ResidualTerm{ResidualSampling}, data) =
     modelcols(t.t, data) + sample!(t.r0, t.r1)
 StatsModels.modelcols(t::ResidualTerm{WildSampling}, data) =
@@ -360,7 +360,7 @@ bootstrap(statistic, data, model, formula, sampling)
 bootstrap(statistic, data, model, formula, Wildsampling(nrun, noise))
 """
 function bootstrap(statistic::Function, data::AbstractDataFrame, model::FormulaModel,
-                   sampling::S) where {S <: BootstrapSampling}
+                   sampling::BootstrapSampling)
     class = model.class
     formula = apply_schema(model.formula, schema(model.formula, data), model.class)
 

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -1,10 +1,10 @@
 ## draw: unify rand, sample
 
-draw!(x::T, o) where {T <: Distribution} = rand!(x, o)
+draw!(x::Distribution, o) = rand!(x, o)
 
-draw!(x::T, o::S) where {T <: AbstractVector,S <: AbstractVector} = sample!(x, o)
+draw!(x::AbstractVector, o::AbstractVector) = sample!(x, o)
 
-function draw!(x::T, o::S) where {T <: AbstractMatrix,S <: AbstractMatrix}
+function draw!(x::AbstractMatrix, o::AbstractMatrix)
     idx = sample(1:nobs(x), nobs(o))
     for (to, from) in enumerate(idx)
         o[to,:] = x[from,:]
@@ -12,7 +12,7 @@ function draw!(x::T, o::S) where {T <: AbstractMatrix,S <: AbstractMatrix}
     return o
 end
 
-function draw!(x::T, o::T) where {T <: AbstractDataFrame}
+function draw!(x::AbstractDataFrame, o::AbstractDataFrame)
     idx = sample(1:nobs(x), nobs(o))
     for column in names(x)
         o[!,column] = x[idx,column]

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -14,9 +14,10 @@ end
 nrun_exact(n::Integer) = binomial(2n - 1, n)
 
 ## Jack-Knife estimate
-function jack_knife_estimate(data, statistic::Function, j::Int = 1, typ::Type = typeof(statistic(data)[j]))
+function jack_knife_estimate(data, statistic::Function, j::Int = 1,
+                             ::Type{T} = typeof(statistic(data)[j])) where T
     n = nobs(data)
-    y = zeros(typ, n)
+    y = zeros(T, n)
     idx = trues(n)
     for i in 1:n
         idx[i] = false


### PR DESCRIPTION
This PR removes unneeded where clauses, as [recommended in the documentation](https://docs.julialang.org/en/v1/manual/style-guide/#Don't-use-unnecessary-static-parameters-1). This was part of https://github.com/juliangehring/Bootstrap.jl/pull/49.

Moreover, this PR adds a where clause to the jack_knife_estimate function since currently the function does not specialize on the last argument (julia does not specialize on arguments of type `Type`). Running
```julia
@code_native Bootstrap.jack_knife_estimate(rand(100), identity, 1)
```
on both the develop branch and this PR shows that this PR simplifies and shortens the native code quite a bit. The benchmark
```julia
using Bootstrap
using BenchmarkTools                                                                      
using StatsBase 

function test_bca_conf_int(n)                                                             
    sample = bootstrap(mean_and_std, rand(25), BasicSampling(n))                          
    ci = BCaConfInt(0.95)                                                                 

    @btime confint($sample, $ci)
end
```
shows that the PR reduces the number of allocations quite a bit. Running it on the develop branch yields
```julia
julia> test_bca_conf_int(100);
  30.868 μs (347 allocations: 33.13 KiB)

julia> test_bca_conf_int(1_000);
  154.672 μs (351 allocations: 47.53 KiB)
```
whereas with this PR I get
```julia
julia> test_bca_conf_int(100);                                                                                                                                                       
  30.176 μs (297 allocations: 32.34 KiB)                                                                                                                                             
                                                                                                                                                                                     
julia> test_bca_conf_int(1_000);                                                                                                                                                     
  155.044 μs (301 allocations: 46.75 KiB)                                                                                                                                            
```