### PR TITLE
Use upper bounds for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ os:
 
 julia:
   - 1.0
-  - 1.1
-  - 1.2
+  - 1
   - nightly
 
 matrix:
@@ -22,7 +21,7 @@ notifications:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.2
+      julia: 1
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,15 @@ julia:
   - 1
   - nightly
 
-matrix:
-  fast_finish: true
-  allow_failures:
-  - julia: nightly
-
 notifications:
   email:
     on_success: never
     on_failure: change
 
 jobs:
+  fast_finish: true
+  allow_failures:
+    - julia: nightly
   include:
     - stage: "Documentation"
       julia: 1

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "e28b5b4c-05e8-5b66-bc03-6f0c0a0a06e0"
 license = "MIT"
 authors = "Julian Gehring"
 repository = "https://github.com/juliangehring/Bootstrap.jl"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -14,9 +14,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
-DataFrames = "≥ 0.19.0"
-GLM = "≥ 1.3.0"
-StatsModels = "≥ 0.6.0"
+DataFrames = "0.19, 0.20, 0.21, 0.22"
+GLM = "1.3"
+StatsModels = "0.6"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
The standard practice is now to have upper bounds so that the package doesn't break when a dependency tags a breaking release.
CompatHelper makes it easy to update the bounds when a new version comes out.
Without these bounds, registering new versions requires manual intervention.

After tagging a release, will fix #72 and will fix #73.